### PR TITLE
Add option to force restart worker in any case

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,7 @@ jobs:
           - default
           - default-extended
           - errors
+          - force-restart
           - gcp
           - gcp-extended
           - koji

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,6 +49,7 @@ jobs:
           - default-extended
           - errors
           - force-restart
+          - force-restart-check-mode
           - gcp
           - gcp-extended
           - koji

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,6 +52,7 @@ jobs:
           - gcp-extended
           - koji
           - proxy
+          - restart-on-config-change
     container:
       image: "quay.io/fedora/fedora:latest"
       # --cgroupns=host needed due to https://github.com/containers/podman/discussions/12898#discussioncomment-4078154

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,8 @@ jobs:
           path: "${{ github.repository }}"
 
       - name: Run ansible-lint
-        uses: ansible-community/ansible-lint-action@main
+        # https://github.com/ansible/ansible-lint-action/issues/178
+        uses: ansible-community/ansible-lint-action@v6.16.0
         with:
           path: "${{ github.repository }}"
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Variables that the user can set are listed and explained below:
 osbuild_worker_server_hostname: ""
 # The osbuild-composer server API base path. If empty, the default value is used.
 osbuild_worker_server_api_base_path: ""
+# Force the restart of the worker service even if the configuration has not changed.
+osbuild_worker_force_restart: false
 
 # Worker proxy configuration.
 osbuild_worker_proxy_server_hostname: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,8 @@
 osbuild_worker_server_hostname: ""
 # The osbuild-composer server API base path. If empty, the default value is used.
 osbuild_worker_server_api_base_path: ""
+# Force the restart of the worker service even if the configuration has not changed.
+osbuild_worker_force_restart: false
 
 # Worker proxy configuration.
 osbuild_worker_proxy_server_hostname: ""

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,5 @@
     name: "{{ osbuild_worker_remote_worker_service_name }}{{ osbuild_worker_server_hostname }}"
     daemon_reload: true
     state: restarted
+  # The role may be run on a fresh system in check mode which would result in failure.
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/molecule/aws-extended/verify.yml
+++ b/molecule/aws-extended/verify.yml
@@ -8,7 +8,7 @@
     osbuild_worker_config_dir_mode: '0755'
     osbuild_worker_config_file: "{{ osbuild_worker_config_dir }}/osbuild-worker.toml"
     osbuild_worker_config_file_mode: '0644'
-    osbuild_worker_remote_worker_service_name: osbuild-remote-worker@
+    osbuild_worker_remote_worker_service_name: "osbuild-remote-worker@{{ test_osbuild_worker_server_hostname }}.service"
     osbuild_worker_secrets_mode: '0400'
 
   tasks:
@@ -27,7 +27,7 @@
 
     - name: Check status of osbuild remote worker service
       ansible.builtin.systemd:
-        name: "{{ osbuild_worker_remote_worker_service_name }}{{ test_osbuild_worker_server_hostname }}"
+        name: "{{ osbuild_worker_remote_worker_service_name }}"
       register: osbuild_remote_worker_service
 
     - name: Check that osbuild remote worker service is enabled and started

--- a/molecule/aws/verify.yml
+++ b/molecule/aws/verify.yml
@@ -8,7 +8,7 @@
     osbuild_worker_config_dir_mode: '0755'
     osbuild_worker_config_file: "{{ osbuild_worker_config_dir }}/osbuild-worker.toml"
     osbuild_worker_config_file_mode: '0644'
-    osbuild_worker_remote_worker_service_name: osbuild-remote-worker@
+    osbuild_worker_remote_worker_service_name: "osbuild-remote-worker@{{ test_osbuild_worker_server_hostname }}.service"
     osbuild_worker_secrets_mode: '0400'
 
   tasks:
@@ -27,7 +27,7 @@
 
     - name: Check status of osbuild remote worker service
       ansible.builtin.systemd:
-        name: "{{ osbuild_worker_remote_worker_service_name }}{{ test_osbuild_worker_server_hostname }}"
+        name: "{{ osbuild_worker_remote_worker_service_name }}"
       register: osbuild_remote_worker_service
 
     - name: Check that osbuild remote worker service is enabled and started

--- a/molecule/azure-extended/verify.yml
+++ b/molecule/azure-extended/verify.yml
@@ -8,7 +8,7 @@
     osbuild_worker_config_dir_mode: '0755'
     osbuild_worker_config_file: "{{ osbuild_worker_config_dir }}/osbuild-worker.toml"
     osbuild_worker_config_file_mode: '0644'
-    osbuild_worker_remote_worker_service_name: osbuild-remote-worker@
+    osbuild_worker_remote_worker_service_name: "osbuild-remote-worker@{{ test_osbuild_worker_server_hostname }}.service"
     osbuild_worker_secrets_mode: '0400'
 
   tasks:
@@ -27,7 +27,7 @@
 
     - name: Check status of osbuild remote worker service
       ansible.builtin.systemd:
-        name: "{{ osbuild_worker_remote_worker_service_name }}{{ test_osbuild_worker_server_hostname }}"
+        name: "{{ osbuild_worker_remote_worker_service_name }}"
       register: osbuild_remote_worker_service
 
     - name: Check that osbuild remote worker service is enabled and started

--- a/molecule/azure/verify.yml
+++ b/molecule/azure/verify.yml
@@ -8,7 +8,7 @@
     osbuild_worker_config_dir_mode: '0755'
     osbuild_worker_config_file: "{{ osbuild_worker_config_dir }}/osbuild-worker.toml"
     osbuild_worker_config_file_mode: '0644'
-    osbuild_worker_remote_worker_service_name: osbuild-remote-worker@
+    osbuild_worker_remote_worker_service_name: "osbuild-remote-worker@{{ test_osbuild_worker_server_hostname }}.service"
     osbuild_worker_secrets_mode: '0400'
 
   tasks:
@@ -27,7 +27,7 @@
 
     - name: Check status of osbuild remote worker service
       ansible.builtin.systemd:
-        name: "{{ osbuild_worker_remote_worker_service_name }}{{ test_osbuild_worker_server_hostname }}"
+        name: "{{ osbuild_worker_remote_worker_service_name }}"
       register: osbuild_remote_worker_service
 
     - name: Check that osbuild remote worker service is enabled and started

--- a/molecule/default-extended/verify.yml
+++ b/molecule/default-extended/verify.yml
@@ -8,7 +8,7 @@
     osbuild_worker_config_dir_mode: '0755'
     osbuild_worker_config_file: "{{ osbuild_worker_config_dir }}/osbuild-worker.toml"
     osbuild_worker_config_file_mode: '0644'
-    osbuild_worker_remote_worker_service_name: osbuild-remote-worker@
+    osbuild_worker_remote_worker_service_name: "osbuild-remote-worker@{{ test_osbuild_worker_server_hostname }}.service"
     osbuild_worker_secrets_mode: '0400'
 
   tasks:
@@ -51,7 +51,7 @@
 
     - name: Check status of osbuild remote worker service
       ansible.builtin.systemd:
-        name: "{{ osbuild_worker_remote_worker_service_name }}{{ test_osbuild_worker_server_hostname }}"
+        name: "{{ osbuild_worker_remote_worker_service_name }}"
       register: osbuild_remote_worker_service
 
     - name: Check that osbuild remote worker service is enabled and started

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -61,6 +61,23 @@
           - osbuild_remote_worker_service.status['ActiveState'] == 'active'
           - osbuild_remote_worker_service.status['UnitFileState'] == 'enabled'
 
+    - name: Get journal log for worker service
+      ansible.builtin.command: journalctl -u "{{ osbuild_worker_remote_worker_service_name }}" --no-pager
+      changed_when: false
+      register: osbuild_remote_worker_service_journal
+
+    - name: Count how many times osbuild remote worker service was started
+      ansible.builtin.set_fact:
+        osbuild_remote_worker_service_starts: "{{ osbuild_remote_worker_service_journal.stdout_lines | \
+          select('search', 'Started ') | list | count }}"
+
+    - name: Check that osbuild remote worker service started only once
+      ansible.builtin.assert:
+        that:
+          - osbuild_remote_worker_service_starts | int == 1
+        fail_msg: "osbuild remote worker service was started {{ osbuild_remote_worker_service_starts }} times
+          but it should be started only once"
+
     - name: Fetch the content of osbuild worker config file (Base64 encoded)
       ansible.builtin.slurp:
         src: "{{ osbuild_worker_config_file }}"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -8,7 +8,7 @@
     osbuild_worker_config_dir_mode: '0755'
     osbuild_worker_config_file: "{{ osbuild_worker_config_dir }}/osbuild-worker.toml"
     osbuild_worker_config_file_mode: '0644'
-    osbuild_worker_remote_worker_service_name: osbuild-remote-worker@
+    osbuild_worker_remote_worker_service_name: "osbuild-remote-worker@{{ test_osbuild_worker_server_hostname }}.service"
     osbuild_worker_secrets_mode: '0400'
 
   tasks:
@@ -51,7 +51,7 @@
 
     - name: Check status of osbuild remote worker service
       ansible.builtin.systemd:
-        name: "{{ osbuild_worker_remote_worker_service_name }}{{ test_osbuild_worker_server_hostname }}"
+        name: "{{ osbuild_worker_remote_worker_service_name }}"
       register: osbuild_remote_worker_service
 
     - name: Check that osbuild remote worker service is enabled and started

--- a/molecule/force-restart-check-mode/Dockerfile.j2
+++ b/molecule/force-restart-check-mode/Dockerfile.j2
@@ -1,0 +1,30 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+ENV container=docker
+
+RUN dnf -y install systemd sudo && dnf clean all && \
+    systemctl mask systemd-remount-fs.service \
+                   dev-hugepages.mount \
+                   sys-fs-fuse-connections.mount \
+                   systemd-logind.service \
+                   getty.target \
+                   console-getty.service && \
+    systemctl disable dnf-makecache.timer \
+                      dnf-makecache.service
+
+VOLUME ["/sys/fs/cgroup"]
+CMD ["/sbin/init"]

--- a/molecule/force-restart-check-mode/converge.yml
+++ b/molecule/force-restart-check-mode/converge.yml
@@ -1,0 +1,18 @@
+---
+- name: Converge
+  hosts: all
+
+  tasks:
+    - name: Include common variables
+      ansible.builtin.include_vars:
+        file: defaults/main.yml
+
+    - name: Include ansible-osbuild-worker role
+      ansible.builtin.include_role:
+        name: "ansible-osbuild-worker"
+      vars:
+        osbuild_worker_server_hostname: "{{ test_osbuild_worker_server_hostname }}"
+        osbuild_worker_authentication_oauth_url: "{{ test_osbuild_worker_authentication_oauth_url }}"
+        osbuild_worker_authentication_client_id: "{{ test_osbuild_worker_authentication_client_id }}"
+        osbuild_worker_authentication_client_secret_file: "{{ test_osbuild_worker_authentication_client_secret_file }}"
+        osbuild_worker_force_restart: true

--- a/molecule/force-restart-check-mode/defaults/main.yml
+++ b/molecule/force-restart-check-mode/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# common variables for force-restart test
+test_osbuild_worker_server_hostname: "composer.example.com"
+test_osbuild_worker_authentication_oauth_url: "https://oauth.example.com"
+test_osbuild_worker_authentication_client_id: "test-client"
+test_osbuild_worker_authentication_client_secret_file: "client_secret"

--- a/molecule/force-restart-check-mode/files/client_secret
+++ b/molecule/force-restart-check-mode/files/client_secret
@@ -1,0 +1,1 @@
+client_secret

--- a/molecule/force-restart-check-mode/molecule.yml
+++ b/molecule/force-restart-check-mode/molecule.yml
@@ -1,0 +1,36 @@
+---
+role_name_check: 1
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: "osbuild-worker-${image:-fedora}-${tag:-latest}"
+    image: "${namespace:-quay.io/fedora}/${image:-fedora}:${tag:-latest}"
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    pre_build_image: false
+    privileged: true
+provisioner:
+  name: ansible
+  options:
+    check: true
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    # this scenario is not idempotent due to the force restart and check mode
+    # - idempotence
+    - side_effect
+    # use the verify.yml from the errors scenario, since the role should not have any effect
+    - verify ../errors/verify.yml
+    - cleanup
+    - destroy

--- a/molecule/force-restart/Dockerfile.j2
+++ b/molecule/force-restart/Dockerfile.j2
@@ -1,0 +1,30 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+ENV container=docker
+
+RUN dnf -y install systemd sudo && dnf clean all && \
+    systemctl mask systemd-remount-fs.service \
+                   dev-hugepages.mount \
+                   sys-fs-fuse-connections.mount \
+                   systemd-logind.service \
+                   getty.target \
+                   console-getty.service && \
+    systemctl disable dnf-makecache.timer \
+                      dnf-makecache.service
+
+VOLUME ["/sys/fs/cgroup"]
+CMD ["/sbin/init"]

--- a/molecule/force-restart/converge.yml
+++ b/molecule/force-restart/converge.yml
@@ -1,0 +1,18 @@
+---
+- name: Converge
+  hosts: all
+
+  tasks:
+    - name: Include common variables
+      ansible.builtin.include_vars:
+        file: defaults/main.yml
+
+    - name: Include ansible-osbuild-worker role
+      ansible.builtin.include_role:
+        name: "ansible-osbuild-worker"
+      vars:
+        osbuild_worker_server_hostname: "{{ test_osbuild_worker_server_hostname }}"
+        osbuild_worker_authentication_oauth_url: "{{ test_osbuild_worker_authentication_oauth_url }}"
+        osbuild_worker_authentication_client_id: "{{ test_osbuild_worker_authentication_client_id }}"
+        osbuild_worker_authentication_client_secret_file: "{{ test_osbuild_worker_authentication_client_secret_file }}"
+        osbuild_worker_force_restart: true

--- a/molecule/force-restart/defaults/main.yml
+++ b/molecule/force-restart/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# common variables for force-restart test
+test_osbuild_worker_server_hostname: "composer.example.com"
+test_osbuild_worker_authentication_oauth_url: "https://oauth.example.com"
+test_osbuild_worker_authentication_client_id: "test-client"
+test_osbuild_worker_authentication_client_secret_file: "client_secret"

--- a/molecule/force-restart/files/client_secret
+++ b/molecule/force-restart/files/client_secret
@@ -1,0 +1,1 @@
+client_secret

--- a/molecule/force-restart/molecule.yml
+++ b/molecule/force-restart/molecule.yml
@@ -1,0 +1,37 @@
+---
+role_name_check: 1
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: "osbuild-worker-${image:-fedora}-${tag:-latest}"
+    image: "${namespace:-quay.io/fedora}/${image:-fedora}:${tag:-latest}"
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    pre_build_image: false
+    privileged: true
+provisioner:
+  name: ansible
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    # this scenario is not idempotent due to the force restart
+    # - idempotence
+    - side_effect
+    # use the verify.yml from the default scenario
+    - verify ../default/verify.yml
+    # instead run the converge once more and verify that the worker was restarted
+    - converge
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/force-restart/verify.yml
+++ b/molecule/force-restart/verify.yml
@@ -1,0 +1,28 @@
+---
+- name: Verify force-restart scenario
+  hosts: all
+  gather_facts: true
+  become: true
+  vars:
+    osbuild_worker_remote_worker_service_name: "osbuild-remote-worker@{{ test_osbuild_worker_server_hostname }}.service"
+
+  tasks:
+    - name: Include common variables
+      ansible.builtin.include_vars:
+        file: defaults/main.yml
+
+    - name: Get journal log for worker service
+      ansible.builtin.command: journalctl -u "{{ osbuild_worker_remote_worker_service_name }}" --no-pager
+      changed_when: false
+      register: osbuild_remote_worker_service_journal
+
+    - name: Count how many times osbuild remote worker service was started
+      ansible.builtin.set_fact:
+        osbuild_remote_worker_service_starts: "{{ osbuild_remote_worker_service_journal.stdout_lines | \
+          select('search', 'Started ') | list | count }}"
+
+    - name: Check that osbuild remote worker service was restarted
+      ansible.builtin.assert:
+        that:
+          - osbuild_remote_worker_service_starts | int == 2
+        fail_msg: "osbuild remote worker service was not restarted"

--- a/molecule/gcp-extended/verify.yml
+++ b/molecule/gcp-extended/verify.yml
@@ -8,7 +8,7 @@
     osbuild_worker_config_dir_mode: '0755'
     osbuild_worker_config_file: "{{ osbuild_worker_config_dir }}/osbuild-worker.toml"
     osbuild_worker_config_file_mode: '0644'
-    osbuild_worker_remote_worker_service_name: osbuild-remote-worker@
+    osbuild_worker_remote_worker_service_name: "osbuild-remote-worker@{{ test_osbuild_worker_server_hostname }}.service"
     osbuild_worker_secrets_mode: '0400'
 
   tasks:
@@ -27,7 +27,7 @@
 
     - name: Check status of osbuild remote worker service
       ansible.builtin.systemd:
-        name: "{{ osbuild_worker_remote_worker_service_name }}{{ test_osbuild_worker_server_hostname }}"
+        name: "{{ osbuild_worker_remote_worker_service_name }}"
       register: osbuild_remote_worker_service
 
     - name: Check that osbuild remote worker service is enabled and started

--- a/molecule/gcp/verify.yml
+++ b/molecule/gcp/verify.yml
@@ -8,7 +8,7 @@
     osbuild_worker_config_dir_mode: '0755'
     osbuild_worker_config_file: "{{ osbuild_worker_config_dir }}/osbuild-worker.toml"
     osbuild_worker_config_file_mode: '0644'
-    osbuild_worker_remote_worker_service_name: osbuild-remote-worker@
+    osbuild_worker_remote_worker_service_name: "osbuild-remote-worker@{{ test_osbuild_worker_server_hostname }}.service"
     osbuild_worker_secrets_mode: '0400'
 
   tasks:
@@ -27,7 +27,7 @@
 
     - name: Check status of osbuild remote worker service
       ansible.builtin.systemd:
-        name: "{{ osbuild_worker_remote_worker_service_name }}{{ test_osbuild_worker_server_hostname }}"
+        name: "{{ osbuild_worker_remote_worker_service_name }}"
       register: osbuild_remote_worker_service
 
     - name: Check that osbuild remote worker service is enabled and started

--- a/molecule/koji/verify.yml
+++ b/molecule/koji/verify.yml
@@ -8,7 +8,7 @@
     osbuild_worker_config_dir_mode: '0755'
     osbuild_worker_config_file: "{{ osbuild_worker_config_dir }}/osbuild-worker.toml"
     osbuild_worker_config_file_mode: '0644'
-    osbuild_worker_remote_worker_service_name: osbuild-remote-worker@
+    osbuild_worker_remote_worker_service_name: "osbuild-remote-worker@{{ test_osbuild_worker_server_hostname }}.service"
     osbuild_worker_secrets_mode: '0400'
 
   tasks:
@@ -27,7 +27,7 @@
 
     - name: Check status of osbuild remote worker service
       ansible.builtin.systemd:
-        name: "{{ osbuild_worker_remote_worker_service_name }}{{ test_osbuild_worker_server_hostname }}"
+        name: "{{ osbuild_worker_remote_worker_service_name }}"
       register: osbuild_remote_worker_service
 
     - name: Check that osbuild remote worker service is enabled and started

--- a/molecule/proxy/verify.yml
+++ b/molecule/proxy/verify.yml
@@ -4,8 +4,10 @@
   gather_facts: true
   become: true
   vars:
-    osbuild_worker_remote_worker_service_name: osbuild-remote-worker@
-    test_systemd_dropin_dir: /etc/systemd/system/{{ osbuild_worker_remote_worker_service_name }}.service.d
+    osbuild_worker_remote_worker_service_template_name: "osbuild-remote-worker@"
+    osbuild_worker_remote_worker_service_name:
+      "{{ osbuild_worker_remote_worker_service_template_name }}{{ test_osbuild_worker_server_hostname }}.service"
+    test_systemd_dropin_dir: /etc/systemd/system/{{ osbuild_worker_remote_worker_service_template_name }}.service.d
     test_systemd_dropin_file: "{{ test_systemd_dropin_dir }}/proxy.conf"
     test_systemd_dropin_file_mode: '0644'
 
@@ -25,7 +27,7 @@
 
     - name: Check status of osbuild remote worker service
       ansible.builtin.systemd:
-        name: "{{ osbuild_worker_remote_worker_service_name }}{{ test_osbuild_worker_server_hostname }}"
+        name: "{{ osbuild_worker_remote_worker_service_name }}"
       register: osbuild_remote_worker_service
 
     - name: Check that osbuild remote worker service is enabled and started

--- a/molecule/restart-on-config-change/Dockerfile.j2
+++ b/molecule/restart-on-config-change/Dockerfile.j2
@@ -1,0 +1,30 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+{% if item.env is defined %}
+{% for var, value in item.env.items() %}
+{% if value %}
+ENV {{ var }} {{ value }}
+{% endif %}
+{% endfor %}
+{% endif %}
+
+ENV container=docker
+
+RUN dnf -y install systemd sudo && dnf clean all && \
+    systemctl mask systemd-remount-fs.service \
+                   dev-hugepages.mount \
+                   sys-fs-fuse-connections.mount \
+                   systemd-logind.service \
+                   getty.target \
+                   console-getty.service && \
+    systemctl disable dnf-makecache.timer \
+                      dnf-makecache.service
+
+VOLUME ["/sys/fs/cgroup"]
+CMD ["/sbin/init"]

--- a/molecule/restart-on-config-change/converge.yml
+++ b/molecule/restart-on-config-change/converge.yml
@@ -1,0 +1,17 @@
+---
+- name: Converge
+  hosts: all
+
+  tasks:
+    - name: Include common variables
+      ansible.builtin.include_vars:
+        file: defaults/main.yml
+
+    - name: Include ansible-osbuild-worker role
+      ansible.builtin.include_role:
+        name: "ansible-osbuild-worker"
+      vars:
+        osbuild_worker_server_hostname: "{{ test_osbuild_worker_server_hostname }}"
+        osbuild_worker_authentication_oauth_url: "{{ test_osbuild_worker_authentication_oauth_url }}"
+        osbuild_worker_authentication_client_id: "{{ test_osbuild_worker_authentication_client_id }}"
+        osbuild_worker_authentication_client_secret_file: "{{ test_osbuild_worker_authentication_client_secret_file }}"

--- a/molecule/restart-on-config-change/defaults/main.yml
+++ b/molecule/restart-on-config-change/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# common variables for restart-on-config-change test
+test_osbuild_worker_server_hostname: "composer.example.com"
+test_osbuild_worker_authentication_oauth_url: "https://oauth.example.com"
+test_osbuild_worker_authentication_client_id: "test-client-changed"
+test_osbuild_worker_authentication_client_secret_file: "client_secret"

--- a/molecule/restart-on-config-change/files/client_secret
+++ b/molecule/restart-on-config-change/files/client_secret
@@ -1,0 +1,1 @@
+client_secret

--- a/molecule/restart-on-config-change/molecule.yml
+++ b/molecule/restart-on-config-change/molecule.yml
@@ -1,0 +1,36 @@
+---
+role_name_check: 1
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: "osbuild-worker-${image:-fedora}-${tag:-latest}"
+    image: "${namespace:-quay.io/fedora}/${image:-fedora}:${tag:-latest}"
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    pre_build_image: false
+    privileged: true
+provisioner:
+  name: ansible
+  playbooks:
+    prepare: ../default/converge.yml
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    # verify that the system is in the correct state before running the test case
+    - verify ../default/verify.yml
+    # now run the actual test case on already configured worker
+    - converge
+    - idempotence
+    - verify
+    - cleanup
+    - destroy

--- a/molecule/restart-on-config-change/verify.yml
+++ b/molecule/restart-on-config-change/verify.yml
@@ -1,0 +1,119 @@
+---
+- name: Verify restart-on-config-change scenario
+  hosts: all
+  gather_facts: true
+  become: true
+  vars:
+    osbuild_worker_config_dir: /etc/osbuild-worker
+    osbuild_worker_config_dir_mode: '0755'
+    osbuild_worker_config_file: "{{ osbuild_worker_config_dir }}/osbuild-worker.toml"
+    osbuild_worker_config_file_mode: '0644'
+    osbuild_worker_remote_worker_service_name: "osbuild-remote-worker@{{ test_osbuild_worker_server_hostname }}.service"
+    osbuild_worker_secrets_mode: '0400'
+
+  tasks:
+    - name: Include common variables
+      ansible.builtin.include_vars:
+        file: defaults/main.yml
+
+    - name: Gather package facts
+      ansible.builtin.package_facts:
+        manager: auto
+
+    - name: Check that osbuild-composer-worker is installed
+      ansible.builtin.assert:
+        that:
+          - ansible_facts.packages['osbuild-composer-worker'] is defined
+
+    - name: Stat osbuild_worker_config_dir
+      ansible.builtin.stat:
+        path: "{{ osbuild_worker_config_dir }}"
+      register: osbuild_worker_config_dir_stat
+
+    - name: Check that osbuild_worker_config_dir exists
+      ansible.builtin.assert:
+        that:
+          - osbuild_worker_config_dir_stat.stat.exists
+          - osbuild_worker_config_dir_stat.stat.isdir
+          - osbuild_worker_config_dir_stat.stat.mode == osbuild_worker_config_dir_mode
+
+    - name: Stat osbuild_worker_config_file
+      ansible.builtin.stat:
+        path: "{{ osbuild_worker_config_file }}"
+      register: osbuild_worker_config_file_stat
+
+    - name: Check that osbuild_worker_config_file exists
+      ansible.builtin.assert:
+        that:
+          - osbuild_worker_config_file_stat.stat.exists
+          - osbuild_worker_config_file_stat.stat.isreg
+          - osbuild_worker_config_file_stat.stat.mode == osbuild_worker_config_file_mode
+
+    - name: Check status of osbuild remote worker service
+      ansible.builtin.systemd:
+        name: "{{ osbuild_worker_remote_worker_service_name }}"
+      register: osbuild_remote_worker_service
+
+    - name: Check that osbuild remote worker service is enabled and started
+      ansible.builtin.assert:
+        that:
+          - osbuild_remote_worker_service.status['LoadState'] == 'loaded'
+          - osbuild_remote_worker_service.status['ActiveState'] == 'active'
+          - osbuild_remote_worker_service.status['UnitFileState'] == 'enabled'
+
+    - name: Get journal log for worker service
+      ansible.builtin.command: journalctl -u "{{ osbuild_worker_remote_worker_service_name }}" --no-pager
+      changed_when: false
+      register: osbuild_remote_worker_service_journal
+
+    - name: Count how many times osbuild remote worker service was started
+      ansible.builtin.set_fact:
+        osbuild_remote_worker_service_starts: "{{ osbuild_remote_worker_service_journal.stdout_lines | \
+          select('search', 'Started ') | list | count }}"
+
+    - name: Check that osbuild remote worker service was restarted once
+      ansible.builtin.assert:
+        that:
+          - osbuild_remote_worker_service_starts | int == 2
+        fail_msg: "osbuild remote worker service was started {{ osbuild_remote_worker_service_starts }} times
+          but it should be started twice"
+
+    - name: Fetch the content of osbuild worker config file (Base64 encoded)
+      ansible.builtin.slurp:
+        src: "{{ osbuild_worker_config_file }}"
+      register: osbuild_worker_config_file_content_encoded
+
+    - name: Register (raw) content of osbuild worker config file as a variable
+      ansible.builtin.set_fact:
+        osbuild_worker_config_file_content: "{{ osbuild_worker_config_file_content_encoded.content | b64decode }}"
+
+    - name: Check the worker config file
+      ansible.builtin.assert:
+        that:
+          - auth_config_part in osbuild_worker_config_file_content
+          - osbuild_worker_config_file_content is not match(".*base_path = .*")
+          - osbuild_worker_config_file_content is not match(".*offline_token = .*")
+          - osbuild_worker_config_file_content is not match(".*\[aws\].*")
+          - osbuild_worker_config_file_content is not match(".*\[azure\].*")
+          - osbuild_worker_config_file_content is not match(".*\[gcp\].*")
+          - osbuild_worker_config_file_content is not match(".*\[koji.+\].*")
+      vars:
+        auth_config_part: |-
+          [authentication]
+          oauth_url = "{{ test_osbuild_worker_authentication_oauth_url }}"
+          client_id = "{{ test_osbuild_worker_authentication_client_id }}"
+          client_secret = "{{ osbuild_worker_config_dir }}/client_secret"
+
+    - name: Stat client_secret file
+      ansible.builtin.stat:
+        path: "{{ test_osbuild_worker_client_secret_file_path }}"
+      vars:
+        test_osbuild_worker_client_secret_file_path: "{{ osbuild_worker_config_dir }}/client_secret"
+      register: client_secret_file_stat
+
+    - name: Check that client_secret file exists on the remote host
+      ansible.builtin.assert:
+        that:
+          - client_secret_file_stat.stat.exists
+          - client_secret_file_stat.stat.isreg
+          - client_secret_file_stat.stat.mode == osbuild_worker_secrets_mode

--- a/tasks/deploy_worker.yml
+++ b/tasks/deploy_worker.yml
@@ -89,6 +89,9 @@
         enabled: false
       loop: "{{ osbuild_remote_worker_services_unwanted }}"
 
+- name: Trigger handlers
+  ansible.builtin.meta: flush_handlers
+
 - name: Start and enable osbuild-remote-worker service
   become: true
   ansible.builtin.service:

--- a/tasks/deploy_worker.yml
+++ b/tasks/deploy_worker.yml
@@ -105,3 +105,5 @@
     name: "{{ osbuild_worker_remote_worker_service_name }}{{ osbuild_worker_server_hostname }}.service"
     state: started
     enabled: true
+  # The role may be run on a fresh system in check mode which would result in failure.
+  ignore_errors: "{{ ansible_check_mode }}"

--- a/tasks/deploy_worker.yml
+++ b/tasks/deploy_worker.yml
@@ -89,6 +89,13 @@
         enabled: false
       loop: "{{ osbuild_remote_worker_services_unwanted }}"
 
+- name: Notify remote worker restart handler on force restart
+  ansible.builtin.debug:
+    msg: "Notifying remote worker restart handler"
+  changed_when: osbuild_worker_force_restart
+  notify: Restart remote worker
+  when: osbuild_worker_force_restart
+
 - name: Trigger handlers
   ansible.builtin.meta: flush_handlers
 


### PR DESCRIPTION
Add option to force restart worker even if there was no configuration change which would trigger the worker restart. This option is useful for playbooks which use this role and need to force the worker restart based on external events (such as installing a new CA certificate on the system).

Side changes:

- Ensure that the worker is not unnecessarily restarted when being configured on a fresh system.
- Add test case verifying that the worker is restarted if its configuration is changes on already configured system.
- Minor refactoring.
- Fixed corner cases when running the role on a fresh host in check_mode (by ignoring errors) and added test case for it.